### PR TITLE
Cyrillic display in logs fixed.

### DIFF
--- a/apps/utils.py
+++ b/apps/utils.py
@@ -51,9 +51,9 @@ def prettify_json_html(data: Union[str, Dict[str, Any]]) -> str:
         HTML-code with pretty JSON and style.
     """
     if isinstance(data, dict):
-        json_string_with_indents = json.dumps(data, sort_keys=True, indent=2)
+        json_string_with_indents = json.dumps(data, sort_keys=True, indent=2, ensure_ascii=False)
     elif isinstance(data, str):
-        json_string_with_indents = json.dumps(json.loads(data), sort_keys=True, indent=2)
+        json_string_with_indents = json.dumps(json.loads(data), sort_keys=True, indent=2, ensure_ascii=False)
     else:
         raise ValueError(f'Unsupported data type received: {type(data)}. String or Dict expected.')
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Cyrillic display in logs fixed.
+
 
 ## [0.4.0] - 2022-05-02
 ### Changed


### PR DESCRIPTION
Now Cyrillic symbols are displayed in the log correctly.