### PR TITLE
Response body strip text disabled.

### DIFF
--- a/apps/forms.py
+++ b/apps/forms.py
@@ -28,6 +28,7 @@ class ResourceStubForm(ModelForm):
 class ResponseStubForm(ModelForm):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self.fields['body'].strip = False
 
         if args:
             return

--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Changed
 - Cyrillic display in logs fixed.
-
+- Response body strip disabled.
 
 ## [0.4.0] - 2022-05-02
 ### Changed


### PR DESCRIPTION
Now spaces and blank lines in the response body will not be auto-stripped.